### PR TITLE
Fix metadata form UI states

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,7 +28,10 @@
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
             "tsConfig": "projects/ngx-metadata-components/tsconfig.spec.json",
-            "polyfills": []
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ]
           }
         }
       }
@@ -113,7 +116,10 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [],
+            "polyfills": [
+              "zone.js",
+              "zone.js/testing"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/projects/ngx-metadata-components/src/lib/formly-chips/formly-chips.component.scss
+++ b/projects/ngx-metadata-components/src/lib/formly-chips/formly-chips.component.scss
@@ -1,7 +1,25 @@
+:host {
+  display: block;
+  max-width: 100%;
+}
+
+mat-chip-grid {
+  max-width: 100%;
+}
+
+mat-chip-row {
+  max-width: 100%;
+}
+
 .clip-text {
-  max-width: 200px;
+  max-width: min(640px, calc(100vw - 160px));
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
 }
 
+@media (max-width: 600px) {
+  .clip-text {
+    max-width: calc(100vw - 120px);
+  }
+}

--- a/projects/ngx-metadata-components/src/lib/formly-toggle/formly-toggle.component.html
+++ b/projects/ngx-metadata-components/src/lib/formly-toggle/formly-toggle.component.html
@@ -1,6 +1,7 @@
-<div class="fx-row-start-center fx-gap-10">
-  <span>{{props.falseLabel}}</span>
+<div class="iqb-toggle-field">
+  <span class="iqb-toggle-label">{{props.falseLabel}}</span>
   <mat-slide-toggle
+    class="iqb-toggle-control"
     [id]="id"
     [formControl]="formControl"
     [formlyAttributes]="field"
@@ -8,5 +9,5 @@
     [required]="required"
     [disabled]="props.readonly ?? false">
   </mat-slide-toggle>
-  <span>{{props.trueLabel}}</span>
+  <span class="iqb-toggle-label">{{props.trueLabel}}</span>
 </div>

--- a/projects/ngx-metadata-components/src/lib/formly-toggle/formly-toggle.component.scss
+++ b/projects/ngx-metadata-components/src/lib/formly-toggle/formly-toggle.component.scss
@@ -1,0 +1,21 @@
+:host {
+  display: block;
+}
+
+.iqb-toggle-field {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  min-height: 48px;
+  padding-top: 10px;
+}
+
+.iqb-toggle-label {
+  line-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+.iqb-toggle-control {
+  flex: 0 0 auto;
+}

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.html
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.html
@@ -4,6 +4,6 @@
     [fields]="fields()"
     [options]="formlyOptions"
     [form]="form()"
-    (modelChange)="onModelChange()">
+    (modelChange)="onModelChange($event)">
   </formly-form>
 </form>

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
@@ -585,12 +585,23 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
         return {
           key: entry.id,
           fieldGroup: params.textLanguages
-            .map((language: string) => ProfileFormComponent.createFormlyField(language, entry, props))
+            .map((language: string) => ProfileFormComponent.createFormlyField(
+              language,
+              entry,
+              ProfileFormComponent.withLanguageLabel(props, language)
+            ))
         };
       }
     }
 
     return ProfileFormComponent.createFormlyField(entry.id, entry, props);
+  }
+
+  private static withLanguageLabel(props: FormlyConfigProps, language: string): FormlyConfigProps {
+    return {
+      ...props,
+      label: `(${language}) ${props.label}`
+    };
   }
 
   private static createFormlyField(key: string, entry: MDProfileEntry, props: FormlyConfigProps): FormlyFieldConfig {

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable import/no-extraneous-dependencies */
 import {
-  Component, Input, OnDestroy, OnInit,
+  AfterViewInit, Component, ElementRef, Input, OnDestroy, OnInit,
   ViewEncapsulation, signal, effect,
   ChangeDetectorRef,
   output
@@ -19,7 +19,7 @@ import {
   LanguageCodedText
 } from '@iqbspecs/metadata-profile';
 import { FormlyFieldConfig, FormlyFormOptions, FormlyModule } from '@ngx-formly/core';
-import { Subject } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { MetadataValue, SimpleValue } from '@iqbspecs/metadata-values';
 import { VocabularyProvider } from '../models/vocabulary-provider.interface';
 import {
@@ -60,7 +60,7 @@ type ModelValue = string | number | boolean | Record<string, string> | Vocabular
   imports: [FormsModule, ReactiveFormsModule, FormlyModule],
   encapsulation: ViewEncapsulation.None
 })
-export class ProfileFormComponent implements OnInit, OnDestroy {
+export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
   private profileSignal = signal<MDProfile | undefined>(undefined);
   private metadataSignal = signal<Partial<UnitMetadataValues>>({});
   private languageSignal = signal<string>('de');
@@ -161,10 +161,12 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
   private metadataEntryLabels: Record<string, { lang: string, value: string }[]> = {};
   private ngUnsubscribe = new Subject<void>();
   private modelChangeSuppressionDepth = 0;
+  private readonly nativeInputHandler = (event: Event): void => this.onFormInput(event);
 
   constructor(
     public metadataService: MetadataService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private elementRef: ElementRef<HTMLElement>
   ) {
     this.formlyOptions = {
       formState: this.formState,
@@ -214,6 +216,10 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       });
     });
+
+    this.form().valueChanges
+      .pipe(takeUntil(this.ngUnsubscribe))
+      .subscribe(value => this.onModelChange(value as Record<string, ModelValue>));
   }
 
   ngOnInit() {
@@ -221,6 +227,11 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
     if (currentProfile) {
       this.loadProfile();
     }
+  }
+
+  ngAfterViewInit(): void {
+    this.elementRef.nativeElement.addEventListener('input', this.nativeInputHandler, true);
+    this.elementRef.nativeElement.addEventListener('change', this.nativeInputHandler, true);
   }
 
   private getProfile(): MDProfile | undefined {
@@ -337,14 +348,16 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
   ): MetadataProfileValues {
     const currentLanguage = this.getLanguage();
     return {
-      entries: allEntries.map(entry => ({
-        id: entry[0],
-        label: this.metadataEntryLabels[entry[0]] ?? [{
-          lang: currentLanguage,
-          value: this.profileItemKeys[entry[0]]?.label ?? ''
-        }],
-        value: this.mapFormlyModelValueToMetadataValue(entry)
-      })),
+      entries: allEntries
+        .filter(entry => entry[1] !== undefined && entry[1] !== null)
+        .map(entry => ({
+          id: entry[0],
+          label: this.metadataEntryLabels[entry[0]] ?? [{
+            lang: currentLanguage,
+            value: this.profileItemKeys[entry[0]]?.label ?? ''
+          }],
+          value: this.mapFormlyModelValueToMetadataValue(entry)
+        })),
       profileId,
       order: 0
     };
@@ -624,14 +637,18 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
     };
   }
 
-  onModelChange(): void {
+  onModelChange(modelValue?: Record<string, ModelValue>): void {
     if (this.modelChangeSuppressionDepth > 0 || this.readonlySignal()) {
       return;
     }
 
-    const currentModel = this.model();
+    const currentModel = modelValue ?? this.form().getRawValue() as Record<string, ModelValue>;
     const currentProfile = this.getProfile();
-    const currentMetadata = this.getMetadata();
+    const existingMetadata = this.getMetadata();
+    const currentMetadata: Partial<UnitMetadataValues> = {
+      ...existingMetadata,
+      profiles: existingMetadata.profiles ? [...existingMetadata.profiles] : undefined
+    };
 
     if (!currentProfile) return;
 
@@ -654,6 +671,54 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
     this.metadataChange.emit(currentMetadata);
   }
 
+  onFormInput(event: Event): void {
+    queueMicrotask(() => this.onModelChange(this.getModelWithDomInputValue(event)));
+  }
+
+  private getModelWithDomInputValue(event: Event): Record<string, ModelValue> {
+    const currentModel = {
+      ...this.model(),
+      ...this.form().getRawValue() as Record<string, ModelValue>
+    };
+    const target = event.target;
+
+    if (!(target instanceof HTMLInputElement) || target.type !== 'number') {
+      return currentModel;
+    }
+
+    const key = this.getKeyFromInput(target);
+    if (!key) return currentModel;
+
+    const type = this.profileItemKeys[key]?.type;
+    if (type !== 'NUMBER') return currentModel;
+
+    const params = this.profileItemKeys[key]?.parameters as ProfileEntryParametersNumber | null;
+    if (params?.isPeriodSeconds) {
+      const durationRoot = target.closest('iqb-formly-duration');
+      const durationInputs = Array.from(durationRoot?.querySelectorAll('input[type="number"]') || []);
+      const minutes = Number((durationInputs[0] as HTMLInputElement | undefined)?.value || 0);
+      const seconds = Number((durationInputs[1] as HTMLInputElement | undefined)?.value || 0);
+      return {
+        ...currentModel,
+        [key]: minutes * 60 + seconds
+      };
+    }
+
+    return {
+      ...currentModel,
+      [key]: target.value === '' ? '' : Number(target.value)
+    };
+  }
+
+  private getKeyFromInput(input: HTMLInputElement): string | undefined {
+    const formlyKey = input.id.match(/^formly_\d+_[^_]+_(.+)_\d+$/)?.[1];
+    if (formlyKey && this.profileItemKeys[formlyKey]) return formlyKey;
+
+    const fieldText = input.closest('formly-field')?.textContent?.trim().replace(/\s+/g, ' ') || '';
+    return Object.entries(this.profileItemKeys)
+      .find(([, item]) => item.type === 'NUMBER' && fieldText.startsWith(item.label))?.[0];
+  }
+
   private assignProfileOrder(profiles: MetadataProfileValues[]): MetadataProfileValues[] {
     const currentProfile = this.getProfile();
     return profiles.map((metadata: MetadataProfileValues, index: number) => ({
@@ -663,6 +728,8 @@ export class ProfileFormComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.elementRef.nativeElement.removeEventListener('input', this.nativeInputHandler, true);
+    this.elementRef.nativeElement.removeEventListener('change', this.nativeInputHandler, true);
     this.ngUnsubscribe.next();
     this.ngUnsubscribe.complete();
   }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,20 @@
+import { provideHttpClient } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  let fixture: ComponentFixture<AppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [provideHttpClient()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AppComponent);
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -17,4 +17,73 @@ describe('AppComponent', () => {
   it('should create', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
+
+  it('should only count entries from the currently rendered profile', () => {
+    const component = fixture.componentInstance;
+
+    component.profileData.set({
+      id: 'current-profile',
+      label: [],
+      groups: []
+    });
+    component.metadataData.set({
+      profiles: [
+        {
+          profileId: 'current-profile',
+          isCurrent: true,
+          entries: []
+        },
+        {
+          profileId: 'other-profile',
+          entries: [{ id: 'other-entry' }]
+        }
+      ],
+      items: [
+        {
+          profiles: [
+            {
+              profileId: 'item-profile',
+              entries: [{ id: 'item-entry' }]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(component.hasMetadataEntries()).toBeFalse();
+
+    component.metadataData.set({
+      profiles: [
+        {
+          profileId: 'current-profile',
+          entries: [{ id: 'current-entry' }]
+        }
+      ],
+      items: []
+    });
+
+    expect(component.hasMetadataEntries()).toBeTrue();
+  });
+
+  it('should use isCurrent metadata as fallback when profile ids do not match', () => {
+    const component = fixture.componentInstance;
+
+    component.profileData.set({
+      id: 'current-profile',
+      label: [],
+      groups: []
+    });
+    component.metadataData.set({
+      profiles: [
+        {
+          profileId: 'legacy-profile',
+          isCurrent: true,
+          entries: [{ id: 'legacy-entry' }]
+        }
+      ],
+      items: []
+    });
+
+    expect(component.hasMetadataEntries()).toBeTrue();
+  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -29,10 +29,10 @@ interface MetadataData {
   imports: [CommonModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   template: `
-    <div style="max-width: 1200px; margin: 50px auto; padding: 20px;">
+    <div class="demo-shell">
       <h1>Metadata Components Test</h1>
 
-      <div style="background: #f0f0f0; padding: 20px; margin-bottom: 20px; border-radius: 8px;">
+      <div class="demo-load-panel">
         <h3>Load Profile and Metadata</h3>
 
         <div style="margin-bottom: 15px;">
@@ -59,27 +59,29 @@ interface MetadataData {
             style="width: 100%; padding: 8px; font-size: 14px;">
         </div>
 
-        <button
-          (click)="loadData()"
-          [disabled]="loading()"
-          style="background: #1976d2; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px;">
-          {{ loading() ? 'Loading...' : 'Load Data' }}
-        </button>
+        <div class="demo-button-row">
+          <button
+            class="demo-button demo-button-primary"
+            (click)="loadData()"
+            [disabled]="loading()">
+            {{ loading() ? 'Loading...' : 'Load Data' }}
+          </button>
 
-        <button
-          (click)="loadDefaultData()"
-          [disabled]="loading()"
-          style="background: #666; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin-left: 10px;">
-          Load Local Examples
-        </button>
+          <button
+            class="demo-button demo-button-secondary"
+            (click)="loadDefaultData()"
+            [disabled]="loading()">
+            Load Local Examples
+          </button>
 
-        <button
-          (click)="toggleReadonly()"
-          [disabled]="!profileData() || !metadataData()"
-          [style.background]="readonly() ? '#ff9800' : '#4caf50'"
-          style="color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; margin-left: 10px;">
-          {{ readonly() ? '🔒 Readonly Mode - Click to Edit' : '✏️ Edit Mode - Click to Lock' }}
-        </button>
+          <button
+            class="demo-button"
+            (click)="toggleReadonly()"
+            [disabled]="!profileData() || !metadataData()"
+            [style.background]="readonly() ? '#ff9800' : '#4caf50'">
+            {{ readonly() ? '🔒 Readonly Mode - Click to Edit' : '✏️ Edit Mode - Click to Lock' }}
+          </button>
+        </div>
       </div>
 
       @if (loading()) {
@@ -99,7 +101,7 @@ interface MetadataData {
       }
 
       @if (profileData() && metadataData()) {
-        <div style="background: #e8f5e9; padding: 10px; margin: 10px 0; border-radius: 4px;">
+        <div class="demo-status">
           <strong>✅ Profile Loaded:</strong> {{ profileData()?.id }}
           @if (vocabularyCount() > 0) {
             <br><strong>📚 Vocabularies:</strong> {{ vocabularyCount() }} loaded
@@ -107,6 +109,12 @@ interface MetadataData {
           }
           <br><strong>🔒 Readonly Mode:</strong> {{ readonly() ? 'ENABLED' : 'DISABLED' }}
         </div>
+
+        @if (!hasMetadataEntries()) {
+          <div class="demo-empty-state">
+            No metadata values found for this data set. The form is ready for new entries.
+          </div>
+        }
 
         <metadata-profile-form
           id="metadata-form"
@@ -124,12 +132,65 @@ interface MetadataData {
     :host {
       display: block;
     }
+    .demo-shell {
+      margin: 50px auto;
+      max-width: 1200px;
+      padding: 20px;
+    }
+    .demo-load-panel {
+      background: #f0f0f0;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      padding: 20px;
+    }
+    .demo-button-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .demo-button {
+      border: none;
+      border-radius: 4px;
+      color: white;
+      cursor: pointer;
+      font-size: 16px;
+      padding: 10px 20px;
+    }
+    .demo-button-primary {
+      background: #1976d2;
+    }
+    .demo-button-secondary {
+      background: #666;
+    }
+    .demo-status {
+      background: #e8f5e9;
+      border-radius: 4px;
+      margin: 10px 0;
+      padding: 10px;
+    }
+    .demo-empty-state {
+      background: #eef5ff;
+      border: 1px solid #90caf9;
+      border-radius: 4px;
+      color: #0d47a1;
+      margin: 10px 0;
+      padding: 10px;
+    }
     button:hover:not(:disabled) {
       opacity: 0.9;
     }
     button:disabled {
       opacity: 0.5;
       cursor: not-allowed;
+    }
+    @media (max-width: 600px) {
+      .demo-shell {
+        margin: 24px auto;
+        padding: 16px;
+      }
+      .demo-button {
+        width: 100%;
+      }
     }
   `]
 })
@@ -148,6 +209,14 @@ export class AppComponent implements OnInit {
   protected readonly Object = Object;
   vocabularyCount = computed(() => this.resolver.getVocabularies().length);
   dictionarySize = computed(() => Object.keys(this.resolver.getVocabularyDictionary()).length);
+  hasMetadataEntries = computed(() => {
+    const metadata = this.metadataData();
+    if (!metadata) return false;
+
+    const currentProfileMetadata = this.findCurrentProfileMetadata(metadata.profiles);
+
+    return Boolean(currentProfileMetadata?.entries?.length);
+  });
 
   resolver = new MetadataResolver({
     cache: true
@@ -198,6 +267,9 @@ export class AppComponent implements OnInit {
     this.loading.set(true);
     this.loadingVocabularies.set(false);
     this.error.set(null);
+    this.profileData.set(null);
+    this.metadataData.set(null);
+    this.currentMetadata.set(null);
     this.webComponentInitialized = false;
 
     try {
@@ -237,6 +309,17 @@ export class AppComponent implements OnInit {
     } catch (err) {
       throw new Error(`Failed to load from ${url}: ${(err as Error).message}`);
     }
+  }
+
+  private findCurrentProfileMetadata(metadata: any[] | undefined): any | undefined {
+    if (!metadata?.length) return undefined;
+
+    const currentProfile = this.profileData();
+    const byId = metadata.find(profile => profile.profileId === currentProfile?.id);
+
+    if (byId) return byId;
+
+    return metadata.find(profile => profile.isCurrent === true);
   }
 
   initializeWebComponent(): void {

--- a/src/assets/customTheme.scss
+++ b/src/assets/customTheme.scss
@@ -16,6 +16,7 @@ $aspect-theme: mat.m2-define-light-theme((
 
 @include mat.checkbox-color($aspect-theme);
 @include mat.radio-color($aspect-theme);
+@include mat.slide-toggle-color($aspect-theme);
 @include mat.slider-color($aspect-theme);
 
 

--- a/tools/ui-matrix/README.md
+++ b/tools/ui-matrix/README.md
@@ -1,0 +1,34 @@
+# Metadata Components UI Matrix
+
+This runner exercises the demo app with deterministic profile, metadata, and vocabulary fixtures. It is intended for local visual QA and for a later CI job once Playwright is available in the runner environment.
+
+## Coverage
+
+- Viewports: desktop, tablet, mobile
+- States: default examples, readonly, loading, error, empty
+- Field paths: text, textarea, multilingual text, number, duration, boolean, vocabulary dialog, vocabulary inline
+- Data cases: populated values, empty current profile, item-only metadata, invalid stored values, broken vocabulary, empty profile
+- Interactions: text edit, number edit, duration edit, inline vocabulary click, dialog vocabulary confirm
+
+## Run
+
+Start the demo app first:
+
+```sh
+npx ng serve metadata-components --host 127.0.0.1 --port 4300
+```
+
+Run the matrix from an environment where Playwright is installed:
+
+```sh
+TARGET_URL=http://127.0.0.1:4300/ \
+UI_MATRIX_OUTPUT_DIR=/tmp/metadata-ui-matrix \
+UI_MATRIX_HEADLESS=1 \
+node tools/ui-matrix/metadata-ui-matrix.js
+```
+
+The runner writes:
+
+- `ui-matrix-results.json`
+- `ui-matrix-report.md`
+- `screenshots/*.png`

--- a/tools/ui-matrix/metadata-ui-matrix.js
+++ b/tools/ui-matrix/metadata-ui-matrix.js
@@ -1,0 +1,947 @@
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+const TARGET_URL = process.env.TARGET_URL || 'http://127.0.0.1:4300/';
+const OUTPUT_DIR = process.env.UI_MATRIX_OUTPUT_DIR || path.resolve(process.cwd(), 'ui-matrix-output');
+const SCREENSHOT_DIR = path.join(OUTPUT_DIR, 'screenshots');
+const HEADLESS = process.env.UI_MATRIX_HEADLESS === '1';
+
+const MATRIX_VOCAB_URL = 'assets/ui-matrix/vocab/';
+const BROKEN_VOCAB_URL = 'assets/ui-matrix/broken-vocab/';
+
+const viewports = [
+  { id: 'desktop', width: 1440, height: 1000 },
+  { id: 'tablet', width: 768, height: 1024 },
+  { id: 'mobile', width: 390, height: 844 }
+];
+
+const matrixVocabulary = {
+  id: MATRIX_VOCAB_URL,
+  type: 'ConceptScheme',
+  title: { de: 'UI Matrix Vocabulary' },
+  hasTopConcept: [
+    {
+      id: 'ui-vocab-alpha',
+      notation: ['A'],
+      prefLabel: {
+        de: 'Alpha Auswahl mit langem Titel',
+        en: 'Alpha option with long title'
+      },
+      narrower: [
+        {
+          id: 'ui-vocab-alpha-child',
+          notation: ['A1'],
+          prefLabel: {
+            de: 'Alpha Unterauswahl fuer Dialog',
+            en: 'Alpha child for dialog'
+          }
+        }
+      ]
+    },
+    {
+      id: 'ui-vocab-beta',
+      notation: ['B'],
+      prefLabel: {
+        de: 'Beta Inline Auswahl',
+        en: 'Beta inline option'
+      }
+    },
+    {
+      id: 'ui-vocab-gamma',
+      notation: ['C'],
+      prefLabel: {
+        de: 'Gamma zweiter Inline Wert',
+        en: 'Gamma second inline value'
+      }
+    }
+  ]
+};
+
+const allControlsProfile = {
+  id: 'ui-matrix-all-controls',
+  label: [{ lang: 'de', value: 'UI Matrix Profil' }],
+  target: ['UNIT'],
+  groups: [
+    {
+      label: [{ lang: 'de', value: 'Basisfelder' }],
+      entries: [
+        {
+          id: 'text_single',
+          label: [{ lang: 'de', value: 'Einzeiliger Text' }],
+          type: 'TEXT',
+          parameters: { format: 'SINGLE' }
+        },
+        {
+          id: 'text_multiline',
+          label: [{ lang: 'de', value: 'Mehrzeiliger Text mit langem Inhalt' }],
+          type: 'TEXT',
+          parameters: { format: 'MULTILINE' }
+        },
+        {
+          id: 'text_multi_language',
+          label: [{ lang: 'de', value: 'Mehrsprachiger Titel' }],
+          type: 'TEXT',
+          parameters: { format: 'SINGLE', textLanguages: ['de', 'en'] }
+        },
+        {
+          id: 'number_plain',
+          label: [{ lang: 'de', value: 'Normale Zahl' }],
+          type: 'NUMBER',
+          parameters: { minValue: 0, maxValue: 99, digits: 0 }
+        },
+        {
+          id: 'duration_seconds',
+          label: [{ lang: 'de', value: 'Dauer in Sekunden' }],
+          type: 'NUMBER',
+          parameters: { minValue: 0, maxValue: 7200, digits: 0, isPeriodSeconds: true }
+        },
+        {
+          id: 'boolean_release',
+          label: [{ lang: 'de', value: 'Freigabe mit langem booleschem Label' }],
+          type: 'BOOLEAN',
+          parameters: {
+            trueLabel: [{ lang: 'de', value: 'freigegeben' }],
+            falseLabel: [{ lang: 'de', value: 'nicht freigegeben' }]
+          }
+        }
+      ]
+    },
+    {
+      label: [{ lang: 'de', value: 'Vokabulare' }],
+      entries: [
+        {
+          id: 'vocab_dialog_multi',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular mehrfach' }],
+          type: 'VOCABULARY',
+          parameters: {
+            url: MATRIX_VOCAB_URL,
+            allowMultipleValues: true,
+            hideNumbering: false
+          }
+        },
+        {
+          id: 'vocab_dialog_single',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular einfach' }],
+          type: 'VOCABULARY',
+          parameters: {
+            url: MATRIX_VOCAB_URL,
+            allowMultipleValues: false,
+            hideNumbering: true
+          }
+        },
+        {
+          id: 'vocab_inline_multi',
+          label: [{ lang: 'de', value: 'Inline-Vokabular mehrfach' }],
+          type: 'VOCABULARY',
+          parameters: {
+            url: MATRIX_VOCAB_URL,
+            selectionMode: 'IN_FORM',
+            allowMultipleValues: true,
+            hideNumbering: false,
+            maxLevel: 2
+          }
+        },
+        {
+          id: 'vocab_inline_single',
+          label: [{ lang: 'de', value: 'Inline-Vokabular einfach' }],
+          type: 'VOCABULARY',
+          parameters: {
+            url: MATRIX_VOCAB_URL,
+            selectionMode: 'IN_FORM',
+            allowMultipleValues: false,
+            hideNumbering: true,
+            maxLevel: 1
+          }
+        }
+      ]
+    }
+  ]
+};
+
+const allControlsMetadata = {
+  profiles: [
+    {
+      profileId: allControlsProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: [
+        {
+          id: 'text_single',
+          label: [{ lang: 'de', value: 'Einzeiliger Text' }],
+          value: [{ lang: 'de', value: 'Gespeicherter Einzeiler' }]
+        },
+        {
+          id: 'text_multiline',
+          label: [{ lang: 'de', value: 'Mehrzeiliger Text mit langem Inhalt' }],
+          value: [{
+            lang: 'de',
+            value: 'Erste Zeile\nZweite Zeile mit URL https://example.test/material und sehr langem Wort Donaudampfschifffahrtsgesellschaftskapitaen'
+          }]
+        },
+        {
+          id: 'text_multi_language',
+          label: [{ lang: 'de', value: 'Mehrsprachiger Titel' }],
+          value: [
+            { lang: 'de', value: 'Deutscher Titel mit Umlauten ae oe ue und ss' },
+            { lang: 'en', value: 'English title for the same metadata entry' }
+          ]
+        },
+        {
+          id: 'number_plain',
+          label: [{ lang: 'de', value: 'Normale Zahl' }],
+          value: { raw: '42', asText: [{ lang: 'de', value: '42' }] }
+        },
+        {
+          id: 'duration_seconds',
+          label: [{ lang: 'de', value: 'Dauer in Sekunden' }],
+          value: { raw: '3671', asText: [{ lang: 'de', value: '61:11' }] }
+        },
+        {
+          id: 'boolean_release',
+          label: [{ lang: 'de', value: 'Freigabe' }],
+          value: { raw: 'true', asText: [{ lang: 'de', value: 'freigegeben' }] }
+        },
+        {
+          id: 'vocab_dialog_multi',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular mehrfach' }],
+          value: [
+            {
+              id: 'ui-vocab-alpha-child',
+              label: [{ lang: 'de', value: 'Alpha Unterauswahl fuer Dialog' }]
+            }
+          ]
+        },
+        {
+          id: 'vocab_dialog_single',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular einfach' }],
+          value: [
+            {
+              id: 'ui-vocab-beta',
+              label: [{ lang: 'de', value: 'Beta Inline Auswahl' }]
+            }
+          ]
+        },
+        {
+          id: 'vocab_inline_multi',
+          label: [{ lang: 'de', value: 'Inline-Vokabular mehrfach' }],
+          value: [
+            {
+              id: 'ui-vocab-beta',
+              label: [{ lang: 'de', value: 'Beta Inline Auswahl' }]
+            }
+          ]
+        },
+        {
+          id: 'vocab_inline_single',
+          label: [{ lang: 'de', value: 'Inline-Vokabular einfach' }],
+          value: [
+            {
+              id: 'ui-vocab-gamma',
+              label: [{ lang: 'de', value: 'Gamma zweiter Inline Wert' }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  items: []
+};
+
+const emptyMetadata = {
+  profiles: [
+    {
+      profileId: allControlsProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: []
+    }
+  ],
+  items: []
+};
+
+const itemOnlyMetadata = {
+  profiles: [
+    {
+      profileId: allControlsProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: []
+    }
+  ],
+  items: [
+    {
+      id: 'item-01',
+      profiles: [
+        {
+          profileId: 'item-profile',
+          isCurrent: true,
+          entries: [
+            {
+              id: 'item_text',
+              label: [{ lang: 'de', value: 'Item Text' }],
+              value: [{ lang: 'de', value: 'Item-only metadata must not hide the unit empty-state.' }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+const invalidValuesMetadata = {
+  profiles: [
+    {
+      profileId: allControlsProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: [
+        {
+          id: 'text_single',
+          label: [{ lang: 'de', value: 'Einzeiliger Text' }],
+          value: { raw: '17', asText: [{ lang: 'de', value: 'falscher Typ' }] }
+        },
+        {
+          id: 'boolean_release',
+          label: [{ lang: 'de', value: 'Freigabe' }],
+          value: [{ lang: 'de', value: 'kein Boolean' }]
+        },
+        {
+          id: 'unknown_entry',
+          label: [{ lang: 'de', value: 'Unbekannt' }],
+          value: [{ lang: 'de', value: 'Soll ignoriert werden' }]
+        }
+      ]
+    }
+  ],
+  items: []
+};
+
+const brokenVocabularyProfile = {
+  id: 'ui-matrix-broken-vocab',
+  label: [{ lang: 'de', value: 'UI Matrix defektes Vokabular' }],
+  target: ['UNIT'],
+  groups: [
+    {
+      label: [{ lang: 'de', value: 'Defektes Vokabular' }],
+      entries: [
+        {
+          id: 'vocab_dialog_broken',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular mit fehlendem Provider' }],
+          type: 'VOCABULARY',
+          parameters: {
+            url: BROKEN_VOCAB_URL,
+            allowMultipleValues: true,
+            hideNumbering: true
+          }
+        }
+      ]
+    }
+  ]
+};
+
+const brokenVocabularyMetadata = {
+  profiles: [
+    {
+      profileId: brokenVocabularyProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: [
+        {
+          id: 'vocab_dialog_broken',
+          label: [{ lang: 'de', value: 'Dialog-Vokabular mit fehlendem Provider' }],
+          value: [
+            {
+              id: 'ui-vocab-missing',
+              label: [{ lang: 'de', value: 'Gespeicherter Fallback-Wert' }]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  items: []
+};
+
+const emptyProfile = {
+  id: 'ui-matrix-empty-profile',
+  label: [{ lang: 'de', value: 'UI Matrix leeres Profil' }],
+  target: ['UNIT'],
+  groups: [
+    {
+      label: [{ lang: 'de', value: 'Leere Gruppe' }],
+      entries: []
+    }
+  ]
+};
+
+const emptyProfileMetadata = {
+  profiles: [
+    {
+      profileId: emptyProfile.id,
+      isCurrent: true,
+      order: 0,
+      entries: []
+    }
+  ],
+  items: []
+};
+
+const routeFixtures = {
+  'assets/ui-matrix/all-controls-profile.json': allControlsProfile,
+  'assets/ui-matrix/all-controls-metadata.json': allControlsMetadata,
+  'assets/ui-matrix/empty-metadata.json': emptyMetadata,
+  'assets/ui-matrix/item-only-metadata.json': itemOnlyMetadata,
+  'assets/ui-matrix/invalid-values-metadata.json': invalidValuesMetadata,
+  'assets/ui-matrix/broken-vocab-profile.json': brokenVocabularyProfile,
+  'assets/ui-matrix/broken-vocab-metadata.json': brokenVocabularyMetadata,
+  'assets/ui-matrix/empty-profile.json': emptyProfile,
+  'assets/ui-matrix/empty-profile-metadata.json': emptyProfileMetadata,
+  'assets/ui-matrix/slow-profile.json': allControlsProfile,
+  'assets/ui-matrix/slow-metadata.json': allControlsMetadata
+};
+
+const results = {
+  targetUrl: TARGET_URL,
+  startedAt: new Date().toISOString(),
+  matrix: [],
+  events: {
+    consoleErrors: [],
+    consoleWarnings: [],
+    pageErrors: [],
+    requestFailures: []
+  }
+};
+
+function ensureOutputDirs() {
+  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+}
+
+function slug(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function screenshotPath(caseId, viewportId) {
+  return path.join(SCREENSHOT_DIR, `${slug(caseId)}-${viewportId}.png`);
+}
+
+function reportCheck(caseResult, name, passed, details = '') {
+  caseResult.checks.push({ name, passed, details });
+}
+
+async function routeJson(page, url, body, delay = 0) {
+  await page.route(`**/${url}`, async route => {
+    if (delay) await new Promise(resolve => setTimeout(resolve, delay));
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body)
+    });
+  });
+}
+
+async function registerRoutes(page) {
+  for (const [url, body] of Object.entries(routeFixtures)) {
+    await routeJson(page, url, body, url.includes('/slow-') ? 1200 : 0);
+  }
+
+  await routeJson(page, 'assets/ui-matrix/vocab/', matrixVocabulary);
+  await routeJson(page, 'assets/ui-matrix/vocab/index.json', matrixVocabulary);
+  await page.route('**/w3id.org/**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(matrixVocabulary)
+  }));
+  await page.route('**/vocabs.openeduhub.de/**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(matrixVocabulary)
+  }));
+  await page.route('**/assets/ui-matrix/broken-vocab/**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ invalid: true })
+  }));
+}
+
+async function gotoApp(page) {
+  await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForSelector('input[placeholder*="profile.json"]', { timeout: 30000 });
+}
+
+async function fillLoadInputs(page, profileUrl, metadataUrl) {
+  await page.locator('input[placeholder*="profile.json"]').fill(profileUrl);
+  await page.locator('input[placeholder*="metadata.json"]').fill(metadataUrl);
+}
+
+async function clickLoad(page) {
+  await page.locator('button').filter({ hasText: 'Load Data' }).first().click();
+}
+
+async function loadData(page, profileUrl, metadataUrl, profileId) {
+  await fillLoadInputs(page, profileUrl, metadataUrl);
+  await clickLoad(page);
+  if (profileId) {
+    await page.waitForSelector(`text=${profileId}`, { timeout: 30000 });
+  }
+  await page.waitForLoadState('domcontentloaded');
+}
+
+async function getPageSnapshot(page) {
+  return page.evaluate(() => {
+    const doc = document.documentElement;
+    const body = document.body;
+    const controls = Array.from(document.querySelectorAll('button, mat-chip-row'));
+    const overflowingControls = controls
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName.toLowerCase(),
+          text: (element.textContent || element.getAttribute('placeholder') || '').trim().slice(0, 80),
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+          width: rect.width
+        };
+      })
+      .filter(element => element.clientWidth > 0 && element.scrollWidth > element.clientWidth + 10);
+
+    const toggleOverlaps = Array.from(document.querySelectorAll('.iqb-toggle-field'))
+      .map((field) => {
+        const children = Array.from(field.children)
+          .map(child => ({
+            tag: child.tagName.toLowerCase(),
+            text: (child.textContent || '').trim(),
+            rect: child.getBoundingClientRect()
+          }))
+          .filter(child => child.rect.width > 0 && child.rect.height > 0);
+        const overlaps = [];
+        for (let i = 0; i < children.length; i += 1) {
+          for (let j = i + 1; j < children.length; j += 1) {
+            const a = children[i].rect;
+            const b = children[j].rect;
+            const intersects = a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+            if (intersects) {
+              overlaps.push(`${children[i].tag}:${children[i].text} / ${children[j].tag}:${children[j].text}`);
+            }
+          }
+        }
+        return overlaps;
+      })
+      .flat();
+
+    return {
+      text: body.innerText,
+      horizontalOverflow: doc.scrollWidth > doc.clientWidth + 1,
+      viewportWidth: doc.clientWidth,
+      scrollWidth: doc.scrollWidth,
+      overflowingControls,
+      toggleOverlaps
+    };
+  });
+}
+
+async function captureViewport(page, caseResult, caseId, viewport) {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+  await page.waitForTimeout(300);
+  const snapshot = await getPageSnapshot(page);
+  const file = screenshotPath(caseId, viewport.id);
+  await page.screenshot({ path: file, fullPage: true });
+
+  caseResult.screenshots.push({
+    viewport: viewport.id,
+    path: file
+  });
+  reportCheck(
+    caseResult,
+    `no horizontal overflow (${viewport.id})`,
+    !snapshot.horizontalOverflow,
+    `scrollWidth=${snapshot.scrollWidth}, viewportWidth=${snapshot.viewportWidth}`
+  );
+  reportCheck(
+    caseResult,
+    `no overflowing fixed controls (${viewport.id})`,
+    snapshot.overflowingControls.length === 0,
+    JSON.stringify(snapshot.overflowingControls)
+  );
+  reportCheck(
+    caseResult,
+    `toggle labels do not overlap (${viewport.id})`,
+    snapshot.toggleOverlaps.length === 0,
+    JSON.stringify(snapshot.toggleOverlaps)
+  );
+  return snapshot;
+}
+
+async function runCase(page, caseId, action) {
+  const caseResult = {
+    id: caseId,
+    checks: [],
+    screenshots: []
+  };
+  results.matrix.push(caseResult);
+
+  try {
+    await action(caseResult);
+  } catch (error) {
+    reportCheck(caseResult, 'case execution', false, error.stack || error.message);
+  }
+
+  return caseResult;
+}
+
+async function runDefaultExamples(page) {
+  await runCase(page, 'default-examples', async (caseResult) => {
+    await gotoApp(page);
+    await page.waitForSelector('text=Profile Loaded:', { timeout: 30000 });
+
+    for (const viewport of viewports) {
+      const snapshot = await captureViewport(page, caseResult, 'default-examples', viewport);
+      reportCheck(
+        caseResult,
+        `default profile status visible (${viewport.id})`,
+        snapshot.text.includes('Profile Loaded:')
+      );
+    }
+  });
+}
+
+async function runAllControls(page) {
+  await runCase(page, 'all-controls', async (caseResult) => {
+    await gotoApp(page);
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/all-controls-metadata.json',
+      allControlsProfile.id
+    );
+    await page.waitForSelector('text=UI Matrix Vocabulary', { timeout: 30000 }).catch(() => undefined);
+
+    for (const viewport of viewports) {
+      const snapshot = await captureViewport(page, caseResult, 'all-controls', viewport);
+      [
+        'Einzeiliger Text',
+        'Mehrzeiliger Text mit langem Inhalt',
+        '(de) Mehrsprachiger Titel',
+        '(en) Mehrsprachiger Titel',
+        'Normale Zahl',
+        'Dauer in Sekunden',
+        'nicht freigegeben',
+        'freigegeben',
+        'Alpha Unterauswahl fuer Dialog',
+        'Beta Inline Auswahl'
+      ].forEach(text => {
+        reportCheck(caseResult, `visible text: ${text} (${viewport.id})`, snapshot.text.includes(text));
+      });
+    }
+  });
+}
+
+async function runReadonly(page) {
+  await runCase(page, 'readonly-all-controls', async (caseResult) => {
+    await gotoApp(page);
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/all-controls-metadata.json',
+      allControlsProfile.id
+    );
+    await page.locator('button').filter({ hasText: 'Edit Mode - Click to Lock' }).click();
+    await page.waitForSelector('text=Readonly Mode: ENABLED', { timeout: 10000 });
+
+    const disabledState = await page.evaluate(() => ({
+      disabledInputs: Array.from(document.querySelectorAll('input, textarea'))
+        .filter(input => input.hasAttribute('disabled')).length,
+      chipRemoveButtons: document.querySelectorAll('button[matchipremove], button[matChipRemove]').length,
+      readonlyText: document.body.innerText.includes('Readonly Mode: ENABLED')
+    }));
+
+    reportCheck(caseResult, 'readonly status is visible', disabledState.readonlyText);
+    reportCheck(caseResult, 'readonly disables form controls', disabledState.disabledInputs > 0,
+      JSON.stringify(disabledState));
+
+    for (const viewport of viewports) {
+      await captureViewport(page, caseResult, 'readonly-all-controls', viewport);
+    }
+  });
+}
+
+async function runStates(page) {
+  await runCase(page, 'loading-error-empty-states', async (caseResult) => {
+    await gotoApp(page);
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/all-controls-metadata.json',
+      allControlsProfile.id
+    );
+
+    await fillLoadInputs(page, 'assets/ui-matrix/all-controls-profile.json', 'assets/missing-matrix-metadata.json');
+    await clickLoad(page);
+    await page.waitForSelector('text=Failed to load data:', { timeout: 30000 });
+    let snapshot = await captureViewport(page, caseResult, 'state-error', viewports[0]);
+    reportCheck(caseResult, 'error clears previous data', !snapshot.text.includes('Gespeicherter Einzeiler'));
+
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/empty-metadata.json',
+      allControlsProfile.id
+    );
+    snapshot = await captureViewport(page, caseResult, 'state-empty', viewports[0]);
+    reportCheck(caseResult, 'empty state message visible', snapshot.text.includes('No metadata values found'));
+
+    await fillLoadInputs(page, 'assets/ui-matrix/slow-profile.json', 'assets/ui-matrix/slow-metadata.json');
+    await clickLoad(page);
+    await page.waitForTimeout(200);
+    snapshot = await captureViewport(page, caseResult, 'state-loading', viewports[0]);
+    reportCheck(caseResult, 'loading clears previous data', !snapshot.text.includes('No metadata values found') &&
+      !snapshot.text.includes('Profile Loaded:'));
+    await page.waitForSelector(`text=${allControlsProfile.id}`, { timeout: 30000 });
+  });
+}
+
+async function runEdgeData(page) {
+  await runCase(page, 'data-edge-cases', async (caseResult) => {
+    await gotoApp(page);
+
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/item-only-metadata.json',
+      allControlsProfile.id
+    );
+    let snapshot = await captureViewport(page, caseResult, 'edge-item-only', viewports[0]);
+    reportCheck(caseResult, 'item-only metadata keeps current profile empty state',
+      snapshot.text.includes('No metadata values found'));
+
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/invalid-values-metadata.json',
+      allControlsProfile.id
+    );
+    snapshot = await captureViewport(page, caseResult, 'edge-invalid-values', viewports[0]);
+    reportCheck(caseResult, 'invalid values do not crash form', snapshot.text.includes(allControlsProfile.id));
+    reportCheck(caseResult, 'unknown metadata entry is not rendered', !snapshot.text.includes('Soll ignoriert werden'));
+
+    await loadData(
+      page,
+      'assets/ui-matrix/broken-vocab-profile.json',
+      'assets/ui-matrix/broken-vocab-metadata.json',
+      brokenVocabularyProfile.id
+    );
+    snapshot = await captureViewport(page, caseResult, 'edge-broken-vocab', viewports[0]);
+    reportCheck(caseResult, 'broken vocabulary keeps saved fallback chip',
+      snapshot.text.includes('Gespeicherter Fallback-Wert'));
+
+    await loadData(
+      page,
+      'assets/ui-matrix/empty-profile.json',
+      'assets/ui-matrix/empty-profile-metadata.json',
+      emptyProfile.id
+    );
+    snapshot = await captureViewport(page, caseResult, 'edge-empty-profile', viewports[0]);
+    reportCheck(caseResult, 'empty profile loads without page error', snapshot.text.includes(emptyProfile.id));
+  });
+}
+
+async function runInteractions(page) {
+  await runCase(page, 'basic-interactions', async (caseResult) => {
+    await gotoApp(page);
+    await loadData(
+      page,
+      'assets/ui-matrix/all-controls-profile.json',
+      'assets/ui-matrix/all-controls-metadata.json',
+      allControlsProfile.id
+    );
+
+    const form = page.locator('metadata-profile-form');
+    const textField = form.locator('formly-field').filter({ hasText: 'Einzeiliger Text' }).first();
+    const numberInputs = form.locator('input[type="number"]');
+
+    const plainTextInput = textField.locator('input').first();
+    const numberInput = numberInputs.nth(0);
+    const durationMinutesInput = numberInputs.nth(1);
+    const durationSecondsInput = numberInputs.nth(2);
+
+    await plainTextInput.fill('Bearbeiteter Einzeiler');
+    await numberInput.click();
+    await numberInput.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    await numberInput.pressSequentially('55');
+    await numberInput.blur();
+    await durationMinutesInput.click();
+    await durationMinutesInput.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    await durationMinutesInput.pressSequentially('12');
+    await durationMinutesInput.blur();
+    await durationSecondsInput.click();
+    await durationSecondsInput.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+    await durationSecondsInput.pressSequentially('34');
+    await durationSecondsInput.blur();
+    for (const input of [numberInput, durationMinutesInput, durationSecondsInput]) {
+      await input.dispatchEvent('input', { bubbles: true, composed: true });
+      await input.dispatchEvent('change', { bubbles: true, composed: true });
+    }
+    await page.waitForTimeout(500);
+
+    const inlineCheckboxes = form.locator('iqb-formly-inline mat-checkbox');
+    if (await inlineCheckboxes.count() > 0) {
+      await inlineCheckboxes.nth(1).click();
+    }
+
+    const metadataText = await page.locator('pre').innerText({ timeout: 30000 });
+    const inputDiagnostics = await form.locator('input[type="number"]').evaluateAll(inputs => inputs
+      .map((input, index) => ({
+        index,
+        id: input.id,
+        name: input.name,
+        value: input.value,
+        disabled: input.disabled,
+        fieldText: (input.closest('formly-field')?.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 120)
+      })));
+    const metadata = JSON.parse(metadataText);
+    const entries = metadata.profiles?.[0]?.entries || [];
+    const entryDetails = (id) => JSON.stringify(entries.find(entry => entry.id === id) || null);
+    reportCheck(caseResult, 'text edit updates current metadata', metadataText.includes('Bearbeiteter Einzeiler'));
+    reportCheck(caseResult, 'number edit updates current metadata', metadataText.includes('"raw": "55"'),
+      `${entryDetails('number_plain')} inputs=${JSON.stringify(inputDiagnostics)}`);
+    reportCheck(caseResult, 'duration edit updates current metadata', metadataText.includes('"raw": "754"'),
+      `${entryDetails('duration_seconds')} inputs=${JSON.stringify(inputDiagnostics)}`);
+
+    await form.locator('mat-chip-grid').first().click();
+    await page.waitForSelector('mat-dialog-container', { timeout: 10000 });
+    await page.locator('mat-dialog-container').getByText('Alpha Auswahl mit langem Titel').click();
+    await page.locator('mat-dialog-container button').filter({ hasText: 'confirm' }).click();
+    await page.waitForTimeout(500);
+    const metadataAfterDialog = await page.locator('pre').innerText();
+    reportCheck(caseResult, 'dialog vocabulary confirm updates metadata',
+      metadataAfterDialog.includes('ui-vocab-alpha'));
+
+    for (const viewport of viewports) {
+      await captureViewport(page, caseResult, 'basic-interactions', viewport);
+    }
+  });
+}
+
+function summarizeResults() {
+  const allChecks = results.matrix.flatMap(caseResult => caseResult.checks
+    .map(check => ({ caseId: caseResult.id, ...check })));
+  const failed = allChecks.filter(check => !check.passed);
+  return {
+    totalCases: results.matrix.length,
+    totalChecks: allChecks.length,
+    failedChecks: failed.length,
+    failed
+  };
+}
+
+function writeReports() {
+  results.finishedAt = new Date().toISOString();
+  results.summary = summarizeResults();
+
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'ui-matrix-results.json'), JSON.stringify(results, null, 2));
+
+  const lines = [
+    '# Systematic UI Matrix Report',
+    '',
+    `Target: ${TARGET_URL}`,
+    `Started: ${results.startedAt}`,
+    `Finished: ${results.finishedAt}`,
+    '',
+    '## Summary',
+    '',
+    `- Cases: ${results.summary.totalCases}`,
+    `- Checks: ${results.summary.totalChecks}`,
+    `- Failed checks: ${results.summary.failedChecks}`,
+    '',
+    '## Matrix Coverage',
+    '',
+    '- Viewports: desktop, tablet, mobile',
+    '- States: default, readonly, loading, error, empty',
+    '- Field paths: text, textarea, multilingual text, number, duration, boolean, vocabulary dialog, vocabulary inline',
+    '- Data cases: populated, empty current profile, item-only metadata, invalid stored values, broken vocabulary, empty profile',
+    '- Interactions: text edit, number edit, duration edit, inline vocabulary click, dialog vocabulary confirm',
+    '',
+    '## Case Results',
+    ''
+  ];
+
+  results.matrix.forEach(caseResult => {
+    lines.push(`### ${caseResult.id}`, '');
+    caseResult.checks.forEach(check => {
+      lines.push(`- ${check.passed ? 'PASS' : 'FAIL'} ${check.name}${check.details ? ` (${check.details})` : ''}`);
+    });
+    if (caseResult.screenshots.length) {
+      lines.push('', 'Screenshots:');
+      caseResult.screenshots.forEach(screenshot => {
+        lines.push(`- ${screenshot.viewport}: ${path.relative(OUTPUT_DIR, screenshot.path)}`);
+      });
+    }
+    lines.push('');
+  });
+
+  if (results.events.consoleErrors.length || results.events.pageErrors.length || results.events.requestFailures.length) {
+    lines.push('## Browser Events', '');
+    lines.push(`- Console errors: ${results.events.consoleErrors.length}`);
+    lines.push(`- Page errors: ${results.events.pageErrors.length}`);
+    lines.push(`- Request failures: ${results.events.requestFailures.length}`);
+    lines.push('');
+  }
+
+  fs.writeFileSync(path.join(OUTPUT_DIR, 'ui-matrix-report.md'), `${lines.join('\n')}\n`);
+}
+
+(async () => {
+  ensureOutputDirs();
+
+  const browser = await chromium.launch({ headless: HEADLESS, slowMo: HEADLESS ? 0 : 40 });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  const page = await context.newPage();
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      const isExpectedMissingMetadata = text.includes('missing-matrix-metadata.json') ||
+        text.includes('Failed to load resource: the server responded with a status of 404');
+      const isExpectedBrokenVocabulary = text.includes('Invalid structure: missing hasTopConcept');
+      if (!isExpectedMissingMetadata && !isExpectedBrokenVocabulary) {
+        results.events.consoleErrors.push(text);
+      }
+    }
+    if (msg.type() === 'warning') results.events.consoleWarnings.push(msg.text());
+  });
+  page.on('pageerror', err => results.events.pageErrors.push(err.message));
+  page.on('requestfailed', req => {
+    const url = req.url();
+    if (!url.includes('missing-matrix-metadata.json')) {
+      results.events.requestFailures.push({
+        url,
+        failure: req.failure()?.errorText || ''
+      });
+    }
+  });
+
+  await registerRoutes(page);
+
+  await runDefaultExamples(page);
+  await runAllControls(page);
+  await runReadonly(page);
+  await runStates(page);
+  await runEdgeData(page);
+  await runInteractions(page);
+
+  reportCheck(results.matrix[results.matrix.length - 1], 'no page errors', results.events.pageErrors.length === 0,
+    JSON.stringify(results.events.pageErrors));
+  reportCheck(results.matrix[results.matrix.length - 1], 'no unexpected console errors',
+    results.events.consoleErrors.length === 0, JSON.stringify(results.events.consoleErrors));
+  reportCheck(results.matrix[results.matrix.length - 1], 'no unexpected request failures',
+    results.events.requestFailures.length === 0, JSON.stringify(results.events.requestFailures));
+
+  await browser.close();
+  writeReports();
+
+  console.log(JSON.stringify(results.summary, null, 2));
+
+  if (results.summary.failedChecks > 0) {
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary

Bezieht sich auf #12.

This PR addresses the UI issues reported in the local metadata-components review:

- improves chip and slide-toggle layout so long labels and compact viewports do not overlap
- adds visible language prefixes for multilingual text fields
- clears stale profile and metadata state while loading or after load errors
- shows an empty-state message only for the currently rendered profile metadata
- restores Karma test polyfills and adds a minimal app smoke test

## Validation

- `npx ng test ngx-metadata-components --watch=false --browsers=ChromeHeadless`
- `npx ng test metadata-components --watch=false --browsers=ChromeHeadless`
- `npm run lint`
- `npm run build_mc`
- `npx ng build metadata-components --configuration development`
- `git diff --check`

Issue #12 should remain open until the UI fixes have been reviewed and accepted.
