### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Build, test, and lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build_mc
+
+      - name: Test library
+        run: npm run test:ci
+
+      - name: Lint
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build_mc": "rm -rf dist/ngx-metadata-components && ng build ngx-metadata-components",
     "build": "npm run build_mc && npm run start",
     "npm_publish": "cd dist/ngx-metadata-components && npm publish --access public",
+    "test:ci": "ng test ngx-metadata-components --watch=false --browsers=ChromeHeadless",
     "lint": "eslint \"src/**/*.ts\" \"projects/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"projects/**/*.ts\" --fix",
     "lint:js": "eslint \"**/*.js\"",


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for push and pull request quality checks
- add an npm `test:ci` script for the library headless Karma test run
- run install, library build, tests, and lint in CI

## Validation
- `npm ci`
- `npm run build_mc`
- `npm run test:ci`
- `npm run lint`

Related issue: #4. The issue should remain open for branch protection follow-up.