### PR TITLE
Break the profile form model/metadata feedback loop

### DIFF
--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.spec.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.spec.ts
@@ -1,8 +1,45 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture, TestBed, fakeAsync, tick
+} from '@angular/core/testing';
 import { FormlyModule } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { MDProfile } from '@iqbspecs/metadata-profile';
 import { ProfileFormComponent } from './profile-form.component';
+import { VocabularyProvider } from '../models/vocabulary-provider.interface';
+import { UnitMetadataValues } from '../models/metadata-values.interface';
+
+const profile = {
+  id: 'p1',
+  label: 'Test Profile',
+  groups: [{
+    label: 'Group 1',
+    entries: [{
+      id: 'field1',
+      type: 'text',
+      label: 'Field 1',
+      parameters: null
+    }]
+  }]
+} as unknown as MDProfile;
+
+const storedMetadata: Partial<UnitMetadataValues> = {
+  profiles: [{
+    entries: [{
+      id: 'field1',
+      label: [{ lang: 'de', value: 'Field 1' }],
+      value: [{ lang: 'de', value: 'Hello' }]
+    }],
+    profileId: 'p1',
+    order: 0
+  }]
+};
+
+const vocabularyProvider: VocabularyProvider = {
+  getVocabularies: () => [{ url: 'v1', data: {} }] as unknown as ReturnType<VocabularyProvider['getVocabularies']>,
+  getVocabularyDictionary: () => ({})
+};
 
 describe('ProfileFormComponent', () => {
   let component: ProfileFormComponent;
@@ -13,6 +50,7 @@ describe('ProfileFormComponent', () => {
       imports: [
         ReactiveFormsModule,
         FormlyModule.forRoot(),
+        FormlyMaterialModule,
         TranslateModule.forRoot()
       ]
     }).compileComponents();
@@ -24,5 +62,52 @@ describe('ProfileFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('load cycle stability (regression for the change-detection loop)', () => {
+    const emissions: Partial<UnitMetadataValues>[] = [];
+
+    beforeEach(fakeAsync(() => {
+      emissions.length = 0;
+      component.metadataChange.subscribe(value => emissions.push(value));
+      component.vocabularyProvider = vocabularyProvider;
+      component.profileData = profile;
+      component.metadataValues = JSON.parse(JSON.stringify(storedMetadata));
+      fixture.detectChanges();
+      tick(100);
+      fixture.detectChanges();
+      tick(100);
+    }));
+
+    it('does not emit metadataChange when the form reports an unchanged model', fakeAsync(() => {
+      const before = emissions.length;
+      // simulate the formly model->form sync echoing the loaded values back,
+      // as it does at check time outside the suppression window
+      component.onModelChange({ field1: 'Hello' });
+      tick(100);
+      component.onModelChange({ field1: 'Hello' });
+      tick(100);
+      expect(emissions.length).toBe(before);
+    }));
+
+    it('still emits metadataChange for real value changes exactly once', fakeAsync(() => {
+      const before = emissions.length;
+      component.onModelChange({ field1: 'Changed' });
+      tick(100);
+      component.onModelChange({ field1: 'Changed' });
+      tick(100);
+      expect(emissions.length).toBe(before + 1);
+    }));
+
+    it('settles after load instead of emitting on every change detection cycle', fakeAsync(() => {
+      const before = emissions.length;
+      // repeated CD cycles must not produce further emissions
+      // (previously each cycle re-set the model and re-fired the loop)
+      Array.from({ length: 5 }).forEach(() => {
+        fixture.detectChanges();
+        tick(100);
+      });
+      expect(emissions.length).toBe(before);
+    }));
   });
 });

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
@@ -269,10 +269,19 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private setModelFromMetadata(model: Record<string, ModelValue>): void {
+    // Formly syncs a new model reference into the form at check time,
+    // which fires form.valueChanges outside the suppression window below.
+    // Only publish models that actually changed, otherwise the sync loops
+    // model -> form -> valueChanges -> onModelChange -> model forever.
+    if (ProfileFormComponent.isContentEqual(model, this.model())) return;
     this.runWithoutModelChange(() => {
       this.model.set(model);
       queueMicrotask(() => this.cdr.detectChanges());
     });
+  }
+
+  private static isContentEqual(a: unknown, b: unknown): boolean {
+    return JSON.stringify(a) === JSON.stringify(b);
   }
 
   private runWithoutModelChange(action: () => void): void {
@@ -667,6 +676,10 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     currentMetadata.profiles = this.assignProfileOrder(currentMetadata.profiles);
+    // Re-emitting unchanged metadata would re-trigger the metadata effect
+    // (fresh object identity every round) and with it the endless
+    // model/form/valueChanges cycle that freezes the tab.
+    if (ProfileFormComponent.isContentEqual(currentMetadata, existingMetadata)) return;
     this.metadataSignal.set(currentMetadata);
     this.metadataChange.emit(currentMetadata);
   }


### PR DESCRIPTION
Fixes #16

## Problem

Rendering the `ProfileFormComponent` with stored metadata for the current profile froze the browser tab and crashed the renderer after a few minutes (out of memory). Interrupt-sampling the hung main thread showed change detection endlessly rebuilding the formly fields (`FormlyChipsComponent_Template`, formly `_build`/`postPopulate`/`setValidators`, fresh `MatFormField` renders) — see #16 for the full stack samples.

The cycle:

1. `setModelFromMetadata()` → `model.set(freshObject)`
2. Formly syncs the new model reference into the form **at check time of a later CD cycle**, not synchronously.
3. `form.valueChanges` therefore fires **outside** the suppression window — `runWithoutModelChange` lifts `modelChangeSuppressionDepth` via `queueMicrotask`, which has long run by then.
4. `onModelChange()` rebuilds `currentMetadata` as a **fresh object** and sets `metadataSignal`.
5. The metadata effect re-runs, maps a **fresh** model object, calls `setModelFromMetadata()` — back to 1, forever, since every round produces new object identities with unchanged content.

## Fix

Break the cycle by content instead of by timing:

- `setModelFromMetadata()` skips `model.set` when the mapped model is content-equal to the current one — no new reference, no formly re-sync, no `valueChanges` echo.
- `onModelChange()` skips `metadataSignal.set` and `metadataChange.emit` when the rebuilt metadata is content-equal to the current signal value.

Real value changes still emit exactly once; loading stored metadata no longer emits at all.

## Tests

- New "load cycle stability" specs: no emission for an unchanged model echo, exactly one emission per real change, and no emissions across repeated CD cycles after load. 2 of the 3 fail on `master` without the fix; all 14 specs pass with it (`npm run test:ci`, ChromeHeadless).
- The spec TestBed now imports `FormlyMaterialModule`, mirroring the real formly type registration (`input` etc.).
- End-to-end against studio-lite (`feature/unit_index_json`): with this fix built into `node_modules`, the previously freezing unit-properties route stays responsive (12/12 CDP responsiveness checks, stable DOM), and the previously renderer-crashing `units.cy.ts` e2e spec passes 26/26 — in 1 minute instead of 5½.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
