### PR TITLE
Fix profile-form focus loss while typing (0.2.8)

### DIFF
--- a/projects/ngx-metadata-components/package.json
+++ b/projects/ngx-metadata-components/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "description": "Angular components for metadata of IQB.",

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form-focus.component.spec.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form-focus.component.spec.ts
@@ -1,0 +1,85 @@
+import {
+  ComponentFixture, TestBed, fakeAsync, tick
+} from '@angular/core/testing';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { MDProfile } from '@iqbspecs/metadata-profile';
+import { ProfileFormComponent } from './profile-form.component';
+import { VocabularyProvider } from '../models/vocabulary-provider.interface';
+
+const vocabularyProvider: VocabularyProvider = {
+  getVocabularies: () => [{ url: 'v1', data: {} }] as unknown as ReturnType<VocabularyProvider['getVocabularies']>,
+  getVocabularyDictionary: () => ({})
+};
+
+const storedMetadata = {
+  profiles: [{
+    entries: [{ id: 'field1', label: [{ lang: 'de', value: 'Field 1' }], value: [{ lang: 'de', value: 'ab' }] }],
+    profileId: 'p1',
+    order: 0
+  }]
+};
+
+const profile = {
+  id: 'p1',
+  label: 'Test Profile',
+  groups: [{
+    label: 'Group 1',
+    entries: [{
+      id: 'field1', type: 'text', label: 'Field 1', parameters: null
+    }]
+  }]
+} as unknown as MDProfile;
+
+describe('ProfileFormComponent focus stability while typing', () => {
+  let fixture: ComponentFixture<ProfileFormComponent>;
+  let component: ProfileFormComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        FormlyModule.forRoot(),
+        FormlyMaterialModule,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileFormComponent);
+    component = fixture.componentInstance;
+  });
+
+  // Regression: the profile effect must not depend on metadataSignal. When it did,
+  // every keystroke re-ran loadProfile() -> fields.set(), rebuilding the formly tree
+  // and detaching the focused input (focus loss + page scroll on each character).
+  it('keeps the same input element attached while typing', fakeAsync(() => {
+    component.formlyWrapper = '';
+    component.profileData = profile;
+    component.panelExpanded = true;
+    component.vocabularyProvider = vocabularyProvider;
+    component.metadataValues = JSON.parse(JSON.stringify(storedMetadata));
+    fixture.detectChanges();
+    tick(100);
+    fixture.detectChanges();
+
+    const input: HTMLInputElement | null = fixture.nativeElement.querySelector('input');
+    expect(input).toBeTruthy();
+    if (!input) return;
+    expect(input.value).toBe('ab');
+
+    input.focus();
+    input.value = 'abc';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    tick(200);
+    fixture.detectChanges();
+    tick(200);
+    fixture.detectChanges();
+
+    const inputAfter: HTMLInputElement | null = fixture.nativeElement.querySelector('input');
+    expect(input.isConnected).toBe(true);
+    expect(inputAfter).toBe(input);
+    expect(input.value).toBe('abc');
+  }));
+});

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
@@ -3,7 +3,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import {
   AfterViewInit, Component, ElementRef, Input, OnDestroy, OnInit,
-  ViewEncapsulation, signal, effect,
+  ViewEncapsulation, signal, effect, untracked,
   ChangeDetectorRef,
   output
 } from '@angular/core';
@@ -261,11 +261,19 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
     const newFields = this.mapProfileToFormlyFieldConfig(currentProfile);
     this.fields.set(newFields);
 
-    const currentMetadata = this.getMetadata();
-    const newModel = this.mapMetadataValuesToFormlyModel(
-      this.findCurrentProfileMetadata(currentMetadata.profiles)
-    );
-    this.setModelFromMetadata(newModel);
+    // Read metadata/model untracked: loadProfile runs inside the profile effect,
+    // and Angular effects subscribe to every signal read during execution. Without
+    // this guard the effect would also depend on metadataSignal (via getMetadata)
+    // and model (via setModelFromMetadata), so every keystroke — which sets
+    // metadataSignal in onModelChange — re-runs loadProfile and rebuilds the whole
+    // formly field tree, detaching the focused input and scrolling the page.
+    untracked(() => {
+      const currentMetadata = this.getMetadata();
+      const newModel = this.mapMetadataValuesToFormlyModel(
+        this.findCurrentProfileMetadata(currentMetadata.profiles)
+      );
+      this.setModelFromMetadata(newModel);
+    });
   }
 
   private setModelFromMetadata(model: Record<string, ModelValue>): void {


### PR DESCRIPTION
## Problem
Beim Tippen in Metadaten-Feldern (Unit- und Item-Profil, alle Feldtypen) verlor das Eingabefeld nach jedem Zeichen den Fokus und die Seite scrollte nach oben — kein Wort eingebbar. Aufgefallen in studio-lite nach dem Umstieg auf die ins Package portierte `ProfileFormComponent`.

## Ursache
Der Profil-Effect ruft `loadProfile()` auf, das intern `metadataSignal` (über `getMetadata`) und `model` (über `setModelFromMetadata`) liest. Angular-Effects abonnieren jedes während der Ausführung gelesene Signal, wodurch der Effect auch von `metadataSignal` abhing. `onModelChange` setzt `metadataSignal` bei jedem Tastendruck → der Effect feuerte erneut → `loadProfile()` → `fields.set()` baute den kompletten Formly-Feldbaum neu auf → getipptes Input-DOM wurde ersetzt (Fokusverlust + Scroll).

## Fix
Den metadaten-/model-abhängigen Teil von `loadProfile` in `untracked(...)` kapseln, sodass der Effect nur noch von `profileSignal` (via `getProfile()`) abhängt. `fields.set()` bleibt außerhalb, damit Profil-Wechsel weiterhin den Feldbaum neu aufbauen.

## Tests
- Neuer Regressionstest `profile-form-focus.component.spec.ts`: tippt in ein Feld und prüft, dass dasselbe `<input>`-Element verbunden bleibt (`isConnected`, gleiche Referenz). Verifiziert: schlägt ohne den Fix fehl, grün mit Fix.
- Vollständige Lib-Suite grün (`npm run test:ci`, 20/20).
- `npm run build_mc` erfolgreich.

## Release
Version-Bump `0.2.7` → `0.2.8`. Nach Merge muss `npm run npm_publish` manuell ausgeführt werden (npm-2FA), danach in studio-lite auf `0.2.8` bumpen.

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)