### PR TITLE
feat: map vocabulary notation onto the spec annotation field

### DIFF
--- a/projects/ngx-metadata-components/package.json
+++ b/projects/ngx-metadata-components/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": "IQB - Institut zur Qualitätsentwicklung im Bildungswesen",
   "license": "MIT",
   "description": "Angular components for metadata of IQB.",

--- a/projects/ngx-metadata-components/src/lib/formly-chips/formly-chips.component.ts
+++ b/projects/ngx-metadata-components/src/lib/formly-chips/formly-chips.component.ts
@@ -100,7 +100,9 @@ export class FormlyChipsComponent extends FieldType<FieldTypeConfig> implements 
       name,
       id: node.id,
       notation,
-      text: [{ lang: 'de', value: `${hideNumbering ? '' : notation} ${label}`.trim() }]
+      // 'text' hält den reinen Begriff; die Nummerierung (notation) reist getrennt und
+      // wird beim Speichern in das Spec-Feld 'annotation' geschrieben (= SKOS-notation).
+      text: [{ lang: 'de', value: label }]
     };
   }
 

--- a/projects/ngx-metadata-components/src/lib/formly-inline/formly-inline.component.ts
+++ b/projects/ngx-metadata-components/src/lib/formly-inline/formly-inline.component.ts
@@ -102,7 +102,8 @@ export class FormlyInlineComponent
       id: option.id,
       name,
       notation: option.notation,
-      text: [{ lang: 'de', value: name }]
+      // 'text' = reiner Begriff; die Nummerierung wandert beim Speichern nach 'annotation'.
+      text: [{ lang: 'de', value: option.label }]
     };
   }
 

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.spec.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.spec.ts
@@ -5,10 +5,11 @@ import { FormlyModule } from '@ngx-formly/core';
 import { FormlyMaterialModule } from '@ngx-formly/material';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { MDProfile } from '@iqbspecs/metadata-profile';
+import { MDProfile, ProfileEntryParametersVocabulary } from '@iqbspecs/metadata-profile';
 import { ProfileFormComponent } from './profile-form.component';
 import { VocabularyProvider } from '../models/vocabulary-provider.interface';
-import { UnitMetadataValues } from '../models/metadata-values.interface';
+import { StoredVocabularyEntry, UnitMetadataValues } from '../models/metadata-values.interface';
+import { VocabularyEntry } from '../models/vocabulary.class';
 
 const profile = {
   id: 'p1',
@@ -62,6 +63,102 @@ describe('ProfileFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('vocabulary notation <-> annotation mapping', () => {
+    // Spec-Feld 'annotation' = interne SKOS-notation (Nummerierung).
+    interface ProfileFormInternals {
+      profileItemKeys: Record<string, {
+        label: string; type: string; parameters: ProfileEntryParametersVocabulary | null;
+      }>;
+      mapFormlyModelValueToMetadataValue(entry: [string, VocabularyEntry[]]): StoredVocabularyEntry[];
+      mapMetaDataEntriesValueToFormlyModelValue(
+        value: StoredVocabularyEntry[], entryId?: string
+      ): VocabularyEntry[];
+    }
+    let internals: ProfileFormInternals;
+
+    const vocabParams = (hideNumbering: boolean): ProfileEntryParametersVocabulary => (
+      { hideNumbering } as unknown as ProfileEntryParametersVocabulary
+    );
+    const setVocabField = (hideNumbering = false): void => {
+      internals.profileItemKeys = {
+        vocabField: { label: 'Vocab', type: 'VOCABULARY', parameters: vocabParams(hideNumbering) }
+      };
+    };
+    const mapToStored = (entry: VocabularyEntry): StoredVocabularyEntry[] => internals
+      .mapFormlyModelValueToMetadataValue(['vocabField', [entry]]);
+    const mapToModel = (stored: StoredVocabularyEntry[]): VocabularyEntry[] => internals
+      .mapMetaDataEntriesValueToFormlyModelValue(stored, 'vocabField');
+
+    beforeEach(() => {
+      internals = component as unknown as ProfileFormInternals;
+    });
+
+    it('writes the internal notation into the spec annotation field on save', () => {
+      setVocabField();
+      const result = mapToStored({
+        id: 'concept-1', name: '1.2 Foo', notation: ['1.2'], text: [{ lang: 'de', value: 'Foo' }]
+      });
+      expect(result).toEqual([{
+        id: 'concept-1',
+        label: [{ lang: 'de', value: 'Foo' }],
+        annotation: [{ lang: 'de', value: '1.2' }]
+      }]);
+    });
+
+    it('emits an empty annotation when the entry has no notation', () => {
+      setVocabField();
+      const result = mapToStored({
+        id: 'concept-1', name: 'Foo', notation: [], text: [{ lang: 'de', value: 'Foo' }]
+      });
+      expect(result[0].annotation).toEqual([]);
+    });
+
+    it('resolves numbering from the dictionary and keeps text as the pure label on load', () => {
+      setVocabField(false);
+      spyOn(component.metadataService, 'vocabulariesIdDictionary').and.returnValue({
+        'concept-1': {
+          id: 'concept-1', name: 'Foo', notation: ['1.2'], text: []
+        }
+      });
+      const result = mapToModel([{
+        id: 'concept-1', label: [{ lang: 'de', value: 'Foo' }], annotation: [{ lang: 'de', value: '1.2' }]
+      }]);
+      expect(result[0].name).toBe('1.2 Foo');
+      expect(result[0].notation).toEqual(['1.2']);
+      expect(result[0].text).toEqual([{ lang: 'de', value: 'Foo' }]);
+    });
+
+    it('reconstructs numbering from annotation when no dictionary entry exists', () => {
+      setVocabField(false);
+      spyOn(component.metadataService, 'vocabulariesIdDictionary').and.returnValue({});
+      const result = mapToModel([{
+        id: 'concept-1', label: [{ lang: 'de', value: 'Foo' }], annotation: [{ lang: 'de', value: '1.2' }]
+      }]);
+      expect(result[0].name).toBe('1.2 Foo');
+      expect(result[0].notation).toEqual(['1.2']);
+    });
+
+    it('omits the numbering from the display name when hideNumbering is true', () => {
+      setVocabField(true);
+      spyOn(component.metadataService, 'vocabulariesIdDictionary').and.returnValue({});
+      const result = mapToModel([{
+        id: 'concept-1', label: [{ lang: 'de', value: 'Foo' }], annotation: [{ lang: 'de', value: '1.2' }]
+      }]);
+      expect(result[0].name).toBe('Foo');
+    });
+
+    it('round-trips notation through save -> load without loss', () => {
+      setVocabField(false);
+      spyOn(component.metadataService, 'vocabulariesIdDictionary').and.returnValue({});
+      const stored = mapToStored({
+        id: 'concept-1', name: '1.2 Foo', notation: ['1.2'], text: [{ lang: 'de', value: 'Foo' }]
+      });
+      const reloaded = mapToModel(stored);
+      expect(reloaded[0].notation).toEqual(['1.2']);
+      expect(reloaded[0].name).toBe('1.2 Foo');
+    });
   });
 
   describe('load cycle stability (regression for the change-detection loop)', () => {

--- a/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
+++ b/projects/ngx-metadata-components/src/lib/profile-form/profile-form.component.ts
@@ -400,7 +400,9 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
           const entry: StoredVocabularyEntry = {
             id: vocabEntry.id,
             label: vocabEntry.text?.map(t => ({ lang: t.lang, value: t.value })) ?? [],
-            annotation: []
+            // Spec-Feld 'annotation' = SKOS-notation (Nummerierung); Anzeige via hideNumbering.
+            annotation: (vocabEntry.notation ?? [])
+              .map(n => ({ lang: currentLanguage, value: n }))
           };
           return entry;
         });
@@ -524,13 +526,18 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
             const dictEntry = vocabDict[v.id];
 
             if (!dictEntry) {
-              const savedText = textLabels.find(label => label.lang === 'de')?.value ||
+              const savedLabel = textLabels.find(label => label.lang === 'de')?.value ||
                 v.id.split('/').pop() ||
                 v.id;
+              // Ohne Dictionary die Nummerierung aus dem Spec-Feld 'annotation' rekonstruieren.
+              const savedNotation = (v.annotation ?? [])
+                .map(a => a.value)
+                .filter(n => !!n);
+              const savedNotationStr = savedNotation[0] || '';
               return {
                 id: v.id,
-                name: savedText,
-                notation: [] as string[],
+                name: `${hideNumbering ? '' : savedNotationStr} ${savedLabel}`.trim(),
+                notation: savedNotation,
                 text: textLabels
               };
             }
@@ -541,7 +548,8 @@ export class ProfileFormComponent implements OnInit, AfterViewInit, OnDestroy {
               id: v.id,
               name: `${hideNumbering ? '' : notation} ${label}`.trim(),
               notation: notation ? [notation] : [] as string[],
-              text: textLabels
+              // 'text' aus dem Dictionary als reiner Begriff (heilt alt gespeicherte Kombi-Labels).
+              text: [{ lang: 'de', value: label }]
             };
           });
         }


### PR DESCRIPTION
## Kontext

Behebt iqb-berlin/metadata-components#22. Das metadata-values@3.x-Feld `annotation` am Vokabular-Eintrag ist die **Nummerierung** (SKOS-`notation`) — anzuzeigen, wenn vorhanden und der Profil-Parameter `hideNumbering` nicht `true` ist (Klärung durch IQB in #22). Der Feldname bleibt aus Spec-Stabilitätsgründen `annotation`.

## Root Cause: Namensverwechslung `notation` ↔ `annotation`

Es gibt zwei gleichnamige `VocabularyEntry`-Typen: intern `{ id, name, notation, text }` (`notation` = Nummerierung) und die Spec-Form `{ id, label?, annotation? }` (kein `notation`-Feld). Der Emit-Pfad mappte internes `text → label` und setzte hart `annotation: []` — das existierende `notation` wurde nie ins Spec-`annotation` verdrahtet und überlebte nur eingebacken im Label. Da das Editier-Formular die Nummer beim Laden ohnehin frisch aus dem Vokabular-Dictionary auflöst, fiel der Verlust nur downstream auf (studio-lite `annotation-dropped`).

## Änderungen

- **Emit** (`profile-form.component.ts`): `annotation` = interne `notation` als `LanguageCodedText[]` statt `[]`; `label` = reiner Begriff.
- **Chip-/Inline-Erzeugung**: `text` = reiner Begriff (Nummer nicht mehr bei der Erzeugung eingebacken).
- **Load**: `hideNumbering` erst bei der Anzeige; ohne Dictionary wird die Nummer aus `annotation` rekonstruiert, mit Dictionary wird `text` als reiner Begriff neu gesetzt (heilt alt gespeicherte Kombi-Labels beim nächsten Speichern).
- Naming-Disziplin: interne Variable bleibt `notation`, am Mapping kommentiert `Spec-annotation = SKOS-notation`.

## Tests

6 neue Specs (Emit, leere Notation, Load mit/ohne Dictionary, `hideNumbering`, Round-trip). **26/26 grün**, Lint + Build sauber. Version 0.2.8 → 0.2.9.

## Downstream

Folgeticket iqb-berlin/studio-lite#1535 konsumiert diese Version (annotation persistieren + anzeigen). Lokal wurden B (dieser PR) und C (studio-lite) bereits gemeinsam gegen den 0.2.9-Build verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)